### PR TITLE
feat: implement basic console

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ rtic-sync = "1.0.2"
 either = { version = "1.9.0", default_features = false }
 lsm303agr = "0.3.0"
 micromath = "2.1.0"
+heapless = "0.8.0"
+futures = { version = "0.3.29", default_features = false }
+nb = "1.1.0"
 
 # cargo build/run
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,6 @@ microbit-v2 = { git = "https://github.com/90degs2infty/microbit.git", branch = "
 [[bin]]
 name = "microtile"
 path = "src/bin/microtile.rs"
+
+[build-dependencies]
+vergen = { version = "8.2.6", features = ["git", "gitcl"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::error::Error;
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder()
+        .git_describe(true, true, None)
+        .emit()?;
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,12 @@
+// The following lints are disabled (=`allow`ed) for the moment being. Turn them
+// active once you start documenting the public interface properly.
+#![allow(
+    missing_docs,
+    rustdoc::missing_crate_level_docs,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc
+)]
+
 use std::error::Error;
 use vergen::EmitBuilder;
 

--- a/src/device/accel.rs
+++ b/src/device/accel.rs
@@ -132,7 +132,7 @@ impl<'a, 'b, T> HorizontalMovementDriver<'a, 'b, T, Stopped> {
             .expect("Failed to enable accel interrupt");
 
         self.accel
-            .set_accel_mode_and_odr(delay, AccelMode::Normal, AccelOutputDataRate::Hz25)
+            .set_accel_mode_and_odr(delay, AccelMode::Normal, AccelOutputDataRate::Hz1)
             .expect("Failed to set accelerometer mode and odr");
 
         HorizontalMovementDriver {

--- a/src/device/accel.rs
+++ b/src/device/accel.rs
@@ -132,7 +132,7 @@ impl<'a, 'b, T> HorizontalMovementDriver<'a, 'b, T, Stopped> {
             .expect("Failed to enable accel interrupt");
 
         self.accel
-            .set_accel_mode_and_odr(delay, AccelMode::Normal, AccelOutputDataRate::Hz1)
+            .set_accel_mode_and_odr(delay, AccelMode::Normal, AccelOutputDataRate::Hz25)
             .expect("Failed to set accelerometer mode and odr");
 
         HorizontalMovementDriver {

--- a/src/device/cli/command.rs
+++ b/src/device/cli/command.rs
@@ -1,3 +1,20 @@
+pub enum CommandError {
+    InvalidCommand,
+}
+
+#[derive(Debug)]
 pub enum Command {
-    VERSION,
+    Version,
+    Help,
+}
+
+impl TryFrom<&[u8]> for Command {
+    type Error = CommandError;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        match value {
+            b"ver" => Ok(Self::Version),
+            b"help" => Ok(Self::Help),
+            _ => Err(CommandError::InvalidCommand),
+        }
+    }
 }

--- a/src/device/cli/command.rs
+++ b/src/device/cli/command.rs
@@ -1,0 +1,3 @@
+pub enum Command {
+    VERSION,
+}

--- a/src/device/cli/downlink.rs
+++ b/src/device/cli/downlink.rs
@@ -1,0 +1,51 @@
+use super::command::Command;
+use futures::{future::poll_fn, task::Poll};
+use heapless::Vec;
+use microbit::hal::{
+    prelude::_embedded_hal_serial_Read,
+    uarte::{Instance, UarteRx},
+};
+use nb::Error;
+use rtic_sync::channel::Sender;
+
+pub const MAILBOX_CAPACITY: usize = 16;
+
+const IN_BUFFER_SIZE: usize = 8;
+
+pub struct DownlinkDriver<T>
+where
+    T: Instance,
+{
+    rx: UarteRx<T>,
+    buffer_in: Vec<u8, IN_BUFFER_SIZE>,
+    command_pipe: Sender<'static, Command, MAILBOX_CAPACITY>,
+}
+
+impl<T> DownlinkDriver<T>
+where
+    T: Instance,
+{
+    pub fn new(rx: UarteRx<T>, mailbox: Sender<'static, Command, MAILBOX_CAPACITY>) -> Self {
+        Self {
+            rx,
+            buffer_in: Vec::<u8, IN_BUFFER_SIZE>::new(),
+            command_pipe: mailbox,
+        }
+    }
+
+    pub async fn run(&mut self) {
+        loop {
+            let val = poll_fn(|_| {
+                self.rx.read().map_or_else(
+                    |e| match e {
+                        Error::WouldBlock => Poll::Pending,
+                        Error::Other(e) => Poll::Ready(Err(e)),
+                    },
+                    |val| Poll::Ready(Ok(val)),
+                )
+            })
+            .await;
+        }
+        todo!()
+    }
+}

--- a/src/device/cli/downlink.rs
+++ b/src/device/cli/downlink.rs
@@ -12,6 +12,7 @@ pub const MAILBOX_CAPACITY: usize = 16;
 
 const IN_BUFFER_SIZE: usize = 8;
 
+#[derive(Debug)]
 pub enum DriverError {
     ReceiverDropped,
 }
@@ -40,7 +41,13 @@ where
 
     pub async fn run(&mut self) -> Result<(), DriverError> {
         loop {
-            if let Ok(byte) = nb_async(|| self.rx.read()).await {
+            if let Ok(byte) = nb_async(|| {
+                defmt::trace!("Reading downlink");
+                self.rx.read()
+            })
+            .await
+            {
+                defmt::warn!("{}", byte);
                 if byte == b';' {
                     if let Ok(cmd) = Command::try_from(self.buffer_in.as_slice()) {
                         self.command_pipe

--- a/src/device/cli/mod.rs
+++ b/src/device/cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod command;

--- a/src/device/cli/mod.rs
+++ b/src/device/cli/mod.rs
@@ -1,3 +1,4 @@
 pub mod command;
 pub mod downlink;
 pub mod receiver;
+pub mod uplink;

--- a/src/device/cli/mod.rs
+++ b/src/device/cli/mod.rs
@@ -1,1 +1,2 @@
 pub mod command;
+pub mod downlink;

--- a/src/device/cli/mod.rs
+++ b/src/device/cli/mod.rs
@@ -1,4 +1,105 @@
+use microbit::hal::uarte::{Baudrate, Error, Instance, Parity, Pins, Uarte};
+use rtic_sync::channel::Channel;
+use uplink::{Message, MAILBOX_CAPACITY as UPLINK_CAPACITY};
+
+use crate::device::cli::{
+    downlink::{DownlinkDriver, MAILBOX_CAPACITY as DOWNLINK_CAPACITY},
+    receiver::CommandReceiver,
+    uplink::UplinkDriver,
+};
+
+use self::command::Command;
+
 pub mod command;
 pub mod downlink;
 pub mod receiver;
 pub mod uplink;
+
+pub struct Resources {
+    peripheral_tx_buf: [u8; 255],
+    peripheral_rx_buf: [u8; 1],
+    str_channel: Channel<Message, UPLINK_CAPACITY>,
+    cmd_channel: Channel<Command, DOWNLINK_CAPACITY>,
+}
+
+impl Default for Resources {
+    fn default() -> Self {
+        Self {
+            peripheral_tx_buf: [0; 255],
+            peripheral_rx_buf: [0; 1],
+            str_channel: Channel::new(),
+            cmd_channel: Channel::new(),
+        }
+    }
+}
+
+/*
+pub struct CliResources<'a> {
+    tx_buf: &'a mut [u8; 255],
+    rx_buf: &'a mut [u8; 1],
+}
+
+impl<'a> CliResources<'a> {
+    pub fn new(tx_buf: &'a mut [u8; 255], rx_buf: &'a mut [u8; 1]) -> Self {
+        Self { tx_buf, rx_buf }
+    }
+}
+
+pub struct Channels<'a> {
+    str: &'a mut Channel<Message, UPLINK_CAPACITY>,
+    cmd: &'a mut Channel<Command, DOWNLINK_CAPACITY>,
+}
+
+impl<'a> Channels<'a> {
+    pub fn new(
+        str: &'a mut Channel<Message, UPLINK_CAPACITY>,
+        cmd: &'a mut Channel<Command, DOWNLINK_CAPACITY>,
+    ) -> Self {
+        Self { str, cmd }
+    }
+}
+
+pub struct Storage<'a, T>
+where
+    T: Instance,
+{
+    uplink: &'a mut MaybeUninit<UplinkDriver<T>>,
+    downlink: &'a mut MaybeUninit<DownlinkDriver<T>>,
+    command_recv: &'a mut MaybeUninit<CommandReceiver>,
+}
+
+impl<'a, T> Storage<'a, T>
+where
+    T: Instance,
+{
+    pub fn new(
+        uplink: &'a mut MaybeUninit<UplinkDriver<T>>,
+        downlink: &'a mut MaybeUninit<DownlinkDriver<T>>,
+        command_recv: &'a mut MaybeUninit<CommandReceiver>,
+    ) -> Self {
+        Self {
+            uplink,
+            downlink,
+            command_recv,
+        }
+    }
+} */
+
+pub fn init<T>(
+    uarte: T,
+    pins: Pins,
+    res: &'static mut Resources,
+) -> Result<(UplinkDriver<T>, DownlinkDriver<T>, CommandReceiver), Error>
+where
+    T: Instance,
+{
+    let uarte = Uarte::<T>::new(uarte, pins, Parity::EXCLUDED, Baudrate::BAUD115200);
+
+    let (tx, rx) = uarte.split(&mut res.peripheral_tx_buf, &mut res.peripheral_rx_buf)?;
+    let (str_send, str_recv) = res.str_channel.split();
+    let (cmd_send, cmd_recv) = res.cmd_channel.split();
+    let uplink = UplinkDriver::<T>::new(tx, str_recv);
+    let downlink = DownlinkDriver::new(rx, cmd_send);
+    let command_recv = CommandReceiver::new(cmd_recv, str_send);
+    Ok((uplink, downlink, command_recv))
+}

--- a/src/device/cli/mod.rs
+++ b/src/device/cli/mod.rs
@@ -1,14 +1,12 @@
-use microbit::hal::uarte::{Baudrate, Error, Instance, Parity, Pins, Uarte};
-use rtic_sync::channel::Channel;
-use uplink::{Message, MAILBOX_CAPACITY as UPLINK_CAPACITY};
-
+use self::command::Command;
 use crate::device::cli::{
     downlink::{DownlinkDriver, MAILBOX_CAPACITY as DOWNLINK_CAPACITY},
     receiver::CommandReceiver,
     uplink::UplinkDriver,
 };
-
-use self::command::Command;
+use microbit::hal::uarte::{Baudrate, Error, Instance, Parity, Pins, Uarte};
+use rtic_sync::channel::Channel;
+use uplink::{Message, MAILBOX_CAPACITY as UPLINK_CAPACITY};
 
 pub mod command;
 pub mod downlink;

--- a/src/device/cli/mod.rs
+++ b/src/device/cli/mod.rs
@@ -31,58 +31,6 @@ impl Default for Resources {
     }
 }
 
-/*
-pub struct CliResources<'a> {
-    tx_buf: &'a mut [u8; 255],
-    rx_buf: &'a mut [u8; 1],
-}
-
-impl<'a> CliResources<'a> {
-    pub fn new(tx_buf: &'a mut [u8; 255], rx_buf: &'a mut [u8; 1]) -> Self {
-        Self { tx_buf, rx_buf }
-    }
-}
-
-pub struct Channels<'a> {
-    str: &'a mut Channel<Message, UPLINK_CAPACITY>,
-    cmd: &'a mut Channel<Command, DOWNLINK_CAPACITY>,
-}
-
-impl<'a> Channels<'a> {
-    pub fn new(
-        str: &'a mut Channel<Message, UPLINK_CAPACITY>,
-        cmd: &'a mut Channel<Command, DOWNLINK_CAPACITY>,
-    ) -> Self {
-        Self { str, cmd }
-    }
-}
-
-pub struct Storage<'a, T>
-where
-    T: Instance,
-{
-    uplink: &'a mut MaybeUninit<UplinkDriver<T>>,
-    downlink: &'a mut MaybeUninit<DownlinkDriver<T>>,
-    command_recv: &'a mut MaybeUninit<CommandReceiver>,
-}
-
-impl<'a, T> Storage<'a, T>
-where
-    T: Instance,
-{
-    pub fn new(
-        uplink: &'a mut MaybeUninit<UplinkDriver<T>>,
-        downlink: &'a mut MaybeUninit<DownlinkDriver<T>>,
-        command_recv: &'a mut MaybeUninit<CommandReceiver>,
-    ) -> Self {
-        Self {
-            uplink,
-            downlink,
-            command_recv,
-        }
-    }
-} */
-
 pub fn init<T>(
     uarte: T,
     pins: Pins,

--- a/src/device/cli/mod.rs
+++ b/src/device/cli/mod.rs
@@ -1,2 +1,3 @@
 pub mod command;
 pub mod downlink;
+pub mod receiver;

--- a/src/device/cli/receiver.rs
+++ b/src/device/cli/receiver.rs
@@ -1,19 +1,75 @@
-use rtic_sync::channel::Receiver;
+use super::{
+    command::Command,
+    downlink::MAILBOX_CAPACITY as IN_CAPACITY,
+    uplink::{Message, MAILBOX_CAPACITY as OUT_CAPACITY},
+};
+use crate::util::StringIter;
+use rtic_sync::channel::{Receiver, Sender};
 
-use super::{command::Command, downlink::MAILBOX_CAPACITY};
+pub enum DriverError {
+    DownlinkSenderDropped,
+    UplinkReceiverDropped,
+    Encoding,
+}
 
 pub struct CommandReceiver {
-    _mailbox: Receiver<'static, Command, MAILBOX_CAPACITY>,
+    incoming: Receiver<'static, Command, IN_CAPACITY>,
+    outgoing: Sender<'static, Message, OUT_CAPACITY>,
 }
 
 impl CommandReceiver {
     #[must_use]
-    pub fn new(mailbox: Receiver<'static, Command, MAILBOX_CAPACITY>) -> Self {
-        Self { _mailbox: mailbox }
+    pub fn new(
+        incoming: Receiver<'static, Command, IN_CAPACITY>,
+        outgoing: Sender<'static, Message, OUT_CAPACITY>,
+    ) -> Self {
+        Self { incoming, outgoing }
     }
 
-    #[allow(clippy::unused_async)]
-    pub async fn run(&mut self) {
-        todo!()
+    pub async fn run(&mut self) -> Result<(), DriverError> {
+        loop {
+            let cmd = self
+                .incoming
+                .recv()
+                .await
+                .map_err(|_| DriverError::DownlinkSenderDropped)?;
+            self.execute(cmd).await?;
+        }
+    }
+
+    async fn execute(&mut self, cmd: Command) -> Result<(), DriverError> {
+        match cmd {
+            Command::Help => self.execute_help().await,
+            Command::Version => todo!(),
+        }
+    }
+
+    async fn execute_help(&mut self) -> Result<(), DriverError> {
+        let help_text = StringIter::<'_, 32>::from(
+            "\r\n\
+            === microtile ===\r\n\
+            \r\n\
+            available commands:\r\n\
+            - help - prints this help message\r\n\
+            - version - prints VCS information\r\n\
+            \r\n\
+            syntax:\r\n\
+            $ <cmd>;
+            where <cmd> is one of above commands\r\n\
+            \r\n\
+            ==================\r\n",
+        );
+
+        for msg in help_text {
+            match msg {
+                Ok(msg) => self
+                    .outgoing
+                    .send(msg)
+                    .await
+                    .map_err(|_| DriverError::UplinkReceiverDropped)?,
+                Err(_) => unreachable!("Hardcoded string should be convertible"),
+            }
+        }
+        Ok(())
     }
 }

--- a/src/device/cli/receiver.rs
+++ b/src/device/cli/receiver.rs
@@ -1,0 +1,19 @@
+use rtic_sync::channel::Receiver;
+
+use super::{command::Command, downlink::MAILBOX_CAPACITY};
+
+pub struct CommandReceiver {
+    _mailbox: Receiver<'static, Command, MAILBOX_CAPACITY>,
+}
+
+impl CommandReceiver {
+    #[must_use]
+    pub fn new(mailbox: Receiver<'static, Command, MAILBOX_CAPACITY>) -> Self {
+        Self { _mailbox: mailbox }
+    }
+
+    #[allow(clippy::unused_async)]
+    pub async fn run(&mut self) {
+        todo!()
+    }
+}

--- a/src/device/cli/receiver.rs
+++ b/src/device/cli/receiver.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use heapless::String;
 use rtic_sync::channel::{Receiver, Sender};
 
+#[derive(Debug)]
 pub enum DriverError {
     DownlinkSenderDropped,
     UplinkReceiverDropped,

--- a/src/device/cli/receiver.rs
+++ b/src/device/cli/receiver.rs
@@ -46,7 +46,7 @@ impl CommandReceiver {
 
     async fn execute_help(&mut self) -> Result<(), DriverError> {
         let help_text = StringIter::<'_, 32>::from(
-            "\r\n\
+            &"\r\n\
             === microtile ===\r\n\
             \r\n\
             available commands:\r\n\

--- a/src/device/cli/receiver.rs
+++ b/src/device/cli/receiver.rs
@@ -54,7 +54,7 @@ impl CommandReceiver {
             \r\n\
             available commands:\r\n\
             - help - prints this help message\r\n\
-            - version - prints VCS information\r\n\
+            - ver - prints VCS information\r\n\
             \r\n\
             syntax:\r\n\
             $ <cmd>;

--- a/src/device/cli/uplink.rs
+++ b/src/device/cli/uplink.rs
@@ -1,0 +1,6 @@
+use heapless::String;
+
+pub const MESSAGE_LENGTH: usize = 32;
+pub type Message = String<MESSAGE_LENGTH>;
+
+pub const MAILBOX_CAPACITY: usize = 32;

--- a/src/device/cli/uplink.rs
+++ b/src/device/cli/uplink.rs
@@ -1,6 +1,34 @@
 use heapless::String;
+use microbit::hal::uarte::{Instance, UarteTx};
+use rtic_sync::channel::Receiver;
 
 pub const MESSAGE_LENGTH: usize = 32;
 pub type Message = String<MESSAGE_LENGTH>;
 
 pub const MAILBOX_CAPACITY: usize = 32;
+
+pub enum DriverError {
+    Other,
+}
+
+pub struct UplinkDriver<T>
+where
+    T: Instance,
+{
+    _tx: UarteTx<T>,
+    _mailbox: Receiver<'static, Message, MAILBOX_CAPACITY>,
+}
+
+impl<T> UplinkDriver<T>
+where
+    T: Instance,
+{
+    #[must_use]
+    pub fn new(_tx: UarteTx<T>, _mailbox: Receiver<'static, Message, MAILBOX_CAPACITY>) -> Self {
+        todo!()
+    }
+
+    pub async fn run(&mut self) -> Result<(), DriverError> {
+        todo!()
+    }
+}

--- a/src/device/cli/uplink.rs
+++ b/src/device/cli/uplink.rs
@@ -42,12 +42,9 @@ where
                 .await
                 .map_err(|_| DriverError::SenderDropped)?;
             write!(self.tx, "{msg}").map_err(|_| DriverError::FormatError)?;
-            nb_async(|| {
-                defmt::trace!("Flushing uplink");
-                self.tx.flush()
-            })
-            .await
-            .map_err(DriverError::UarteError)?;
+            nb_async(|| self.tx.flush())
+                .await
+                .map_err(DriverError::UarteError)?;
         }
     }
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,5 +1,6 @@
 pub mod accel;
 pub mod button;
+pub mod cli;
 pub mod display;
 pub mod errata;
 pub mod timer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,4 @@ pub fn exit() -> ! {
 
 pub mod device;
 pub mod game;
+pub mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,17 @@
+use futures::{future::poll_fn, task::Poll, Future};
+use nb::{Error, Result as NbResult};
+
+pub fn nb_async<F, T, E>(mut f: F) -> impl Future<Output = Result<T, E>>
+where
+    F: FnMut() -> NbResult<T, E>,
+{
+    poll_fn(move |_| {
+        f().map_or_else(
+            |e| match e {
+                Error::WouldBlock => Poll::Pending,
+                Error::Other(e) => Poll::Ready(Err(e)),
+            },
+            |val| Poll::Ready(Ok(val)),
+        )
+    })
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,21 +1,49 @@
-use core::{cmp::min, str::FromStr};
+use core::{cmp::min, pin::Pin, str::FromStr};
 use futures::{future::poll_fn, task::Poll, Future};
 use heapless::String;
 use nb::{Error, Result as NbResult};
 
-pub fn nb_async<F, T, E>(mut f: F) -> impl Future<Output = Result<T, E>>
+pub struct BusyWait<F> {
+    f: F,
+}
+
+impl<F> BusyWait<F> {
+    pub fn new(f: F) -> Self {
+        Self { f }
+    }
+}
+
+// TODO: am I allowed to implement Unpin?!
+impl<F> Unpin for BusyWait<F> {}
+
+impl<F, T, E> Future for BusyWait<F>
 where
     F: FnMut() -> NbResult<T, E>,
 {
-    poll_fn(move |_| {
-        f().map_or_else(
+    type Output = Result<T, E>;
+
+    fn poll(
+        mut self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        (&mut self.f)().map_or_else(
             |e| match e {
-                Error::WouldBlock => Poll::Pending,
+                Error::WouldBlock => {
+                    cx.waker().clone().wake();
+                    Poll::Pending
+                }
                 Error::Other(e) => Poll::Ready(Err(e)),
             },
             |val| Poll::Ready(Ok(val)),
         )
-    })
+    }
+}
+
+pub fn nb_async<F, T, E>(f: F) -> impl Future<Output = Result<T, E>>
+where
+    F: FnMut() -> NbResult<T, E>,
+{
+    BusyWait::new(f)
 }
 
 pub struct StringIter<'a, const N: usize> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,10 +23,13 @@ pub struct StringIter<'a, const N: usize> {
     cursor: usize,
 }
 
-impl<'a, const N: usize> From<&'a str> for StringIter<'a, N> {
-    fn from(value: &'a str) -> Self {
+impl<'a, const N: usize, P> From<&'a P> for StringIter<'a, N>
+where
+    P: AsRef<str>,
+{
+    fn from(value: &'a P) -> Self {
         Self {
-            raw: value,
+            raw: value.as_ref(),
             cursor: 0,
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,14 +1,14 @@
-use core::{cmp::min, pin::Pin, str::FromStr};
-use futures::{future::poll_fn, task::Poll, Future};
+use core::{cmp::min, str::FromStr};
+use futures::{task::Poll, Future};
 use heapless::String;
 use nb::{Error, Result as NbResult};
 
-pub struct BusyWait<F> {
+struct BusyWait<F> {
     f: F,
 }
 
 impl<F> BusyWait<F> {
-    pub fn new(f: F) -> Self {
+    fn new(f: F) -> Self {
         Self { f }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,6 @@
+use core::{cmp::min, str::FromStr};
 use futures::{future::poll_fn, task::Poll, Future};
+use heapless::String;
 use nb::{Error, Result as NbResult};
 
 pub fn nb_async<F, T, E>(mut f: F) -> impl Future<Output = Result<T, E>>
@@ -14,4 +16,35 @@ where
             |val| Poll::Ready(Ok(val)),
         )
     })
+}
+
+pub struct StringIter<'a, const N: usize> {
+    raw: &'a str,
+    cursor: usize,
+}
+
+impl<'a, const N: usize> From<&'a str> for StringIter<'a, N> {
+    fn from(value: &'a str) -> Self {
+        Self {
+            raw: value,
+            cursor: 0,
+        }
+    }
+}
+
+impl<'a, const N: usize> Iterator for StringIter<'a, N> {
+    type Item = Result<String<N>, ()>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor < self.raw.len() {
+            let chunk_length = min(N, self.raw.len() - self.cursor);
+            let res = Some(String::<N>::from_str(
+                &self.raw[self.cursor..(self.cursor + chunk_length)],
+            ));
+            self.cursor += chunk_length;
+            res
+        } else {
+            None
+        }
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,6 +16,11 @@ impl<F> BusyWait<F> {
 // TODO: am I allowed to implement Unpin?!
 impl<F> Unpin for BusyWait<F> {}
 
+// `BusyWait`'s implementation of Future works by busy waiting for the result to
+// become ready. I.e. in the poll method, when obtaining a `Error::WouldBlock`
+// value, we wake the owning task directly again.
+// Note that while this works for RTIC's executor, it may well lead to
+// starvation of other tasks when executed on other executors.
 impl<F, T, E> Future for BusyWait<F>
 where
     F: FnMut() -> NbResult<T, E>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -31,10 +31,10 @@ where
         mut self: core::pin::Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
     ) -> Poll<Self::Output> {
-        (&mut self.f)().map_or_else(
+        (self.f)().map_or_else(
             |e| match e {
                 Error::WouldBlock => {
-                    cx.waker().clone().wake();
+                    cx.waker().wake_by_ref();
                     Poll::Pending
                 }
                 Error::Other(e) => Poll::Ready(Err(e)),

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,6 +21,7 @@ impl<F> Unpin for BusyWait<F> {}
 // value, we wake the owning task directly again.
 // Note that while this works for RTIC's executor, it may well lead to
 // starvation of other tasks when executed on other executors.
+// Even with RITC, this implementation relies on undocumented behaviour!
 impl<F, T, E> Future for BusyWait<F>
 where
     F: FnMut() -> NbResult<T, E>,


### PR DESCRIPTION
Summary of changes implemented in this PR:

- write up a module `cli` containing drivers to drive the processing of commands
  - `DownlinkDriver` takes care of consuming serial data coming from the host,
    mapping byte-strings to commands
  - `CommandReceiver` drives execution of commands
  - `UplinkDriver` takes care of sending strings back to the host by means of the
    serial interface
- write up a `util` module featuring several helpers
  - `nb_async` to bridge between `nb::Result` and `async` Rust by means of busy
    waiting
  - `StringIter` to aid conversion from `&str` to message-passable
    `heapless::String`s
- "serial" commands `help` and `ver` to print a help string and VCS information
  respectively

Closes #28