### PR TITLE
refactor: revisit defmt based printing

### DIFF
--- a/src/bin/microtile.rs
+++ b/src/bin/microtile.rs
@@ -125,9 +125,14 @@ mod app {
 
         let board = Board::new(cx.device, cx.core);
 
+        defmt::info!(
+            "Taking care of known third-party errata. \
+            This will take some time, please be patient."
+        );
         let mut delay = Timer::new(board.TIMER2);
         let (twim0, pins) =
             clear_int_i2c_interrupt_line(board.TWIM0, board.i2c_internal, &mut delay);
+        defmt::info!("Done taking care of errata.");
 
         // Setup commandline interface
         let cli_resources = cx.local.cli_resources_mem.write(CliResources::default());

--- a/src/bin/microtile.rs
+++ b/src/bin/microtile.rs
@@ -247,6 +247,7 @@ mod app {
 
     #[task(priority = 1, local = [ next_frame_passive: bool = false ], shared = [ display, passive_frame, merged_frame ])]
     async fn display_toggle_frame(cx: display_toggle_frame::Context) {
+        defmt::trace!("microtile_app::display_toggle_frame()");
         if *cx.local.next_frame_passive {
             (cx.shared.display, cx.shared.passive_frame)
                 .lock(|display, frame| display.show_frame(frame));
@@ -259,6 +260,7 @@ mod app {
 
     #[task(binds = TIMER0, priority = 4, shared = [ display ])]
     fn drive_display_low_level(mut cx: drive_display_low_level::Context) {
+        defmt::trace!("microtile_app::drive_display_low_level()");
         cx.shared.display.lock(|display| {
             display.handle_display_event();
         });
@@ -302,6 +304,7 @@ mod app {
 
     #[task(binds = TIMER2, priority = 4, local = [ timer_handler ])]
     fn tick_game(cx: tick_game::Context) {
+        defmt::trace!("microtile_app::tick_game()");
         match cx.local.timer_handler.handle_timer_event() {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
@@ -322,6 +325,8 @@ mod app {
 
     #[task(binds = GPIOTE, priority = 4, local = [ rotation_handler, horizontal_handler ])]
     fn handle_gpio_events(cx: handle_gpio_events::Context) {
+        defmt::trace!("microtile_app::handle_gpio_events()");
+
         // TODO: pull out detection of who is responsible for the event handling?
         match cx.local.rotation_handler.handle_button_event() {
             Ok(()) => {}
@@ -330,6 +335,7 @@ mod app {
             }
             Err(TrySendError::NoReceiver(_)) => unreachable!(),
         };
+
         #[allow(clippy::match_same_arms)]
         match cx.local.horizontal_handler.handle_accel_event() {
             Ok(()) => {}

--- a/src/bin/microtile.rs
+++ b/src/bin/microtile.rs
@@ -265,7 +265,6 @@ mod app {
 
     #[task(binds = TIMER0, priority = 4, shared = [ display ])]
     fn drive_display_low_level(mut cx: drive_display_low_level::Context) {
-        defmt::trace!("microtile_app::drive_display_low_level()");
         cx.shared.display.lock(|display| {
             display.handle_display_event();
         });

--- a/src/bin/microtile.rs
+++ b/src/bin/microtile.rs
@@ -201,6 +201,8 @@ mod app {
         highlevel_display.enable_interrupt();
         highlevel_display.start(HIGH_LEVEL_DISPLAY_CYCLES);
 
+        defmt::info!("Ready, set, go! The game is just about to start!");
+
         unsafe {
             NVIC::unmask(HighLevelDisplayDriver::INTERRUPT);
         }

--- a/src/device/accel.rs
+++ b/src/device/accel.rs
@@ -164,7 +164,10 @@ impl<'a, 'b, T> HorizontalMovementDriver<'a, 'b, T, Started> {
         PinE: Debug,
         D: DelayUs<u32>,
     {
-        defmt::warn!("Stopping the horizontal movement driver is currently untested. The accelerometer is prone to blocking.");
+        defmt::warn!(
+            "Stopping the HorizontalMovementDriver is currently untested. \
+            The accelerometer is prone to blocking."
+        );
 
         self.irq_event.disable_interrupt();
 
@@ -209,7 +212,7 @@ impl<'a, 'b, T> HorizontalMovementDriver<'a, 'b, T, Started> {
         CommE: Debug,
         PinE: Debug,
     {
-        defmt::trace!("handle_accel_event()");
+        defmt::trace!("HorizontalMovementDriver::handle_accel_event()");
 
         // We have to check the channel for having a pending event, because of the way
         // the Gpiote peripheral works: there is a single Gpiote IRQ which gets pended
@@ -223,7 +226,7 @@ impl<'a, 'b, T> HorizontalMovementDriver<'a, 'b, T, Started> {
                 .acceleration()
                 .map_err(<Error<CommE, PinE> as Into<AccelError<CommE, PinE>>>::into)?
                 .xyz_mg();
-            defmt::trace!("Acceleration: {} {} {}", x, y, z,);
+            defmt::debug!("Obtained acceleration: {} {} {}", x, y, z,);
             self.command_pipe
                 .try_send(Message::acceleration(
                     Self::cap_sensor_value(x),

--- a/src/device/accel.rs
+++ b/src/device/accel.rs
@@ -212,8 +212,6 @@ impl<'a, 'b, T> HorizontalMovementDriver<'a, 'b, T, Started> {
         CommE: Debug,
         PinE: Debug,
     {
-        defmt::trace!("HorizontalMovementDriver::handle_accel_event()");
-
         // We have to check the channel for having a pending event, because of the way
         // the Gpiote peripheral works: there is a single Gpiote IRQ which gets pended
         // if there is an event _on any_ of the available channels.

--- a/src/device/cli/downlink.rs
+++ b/src/device/cli/downlink.rs
@@ -42,6 +42,8 @@ where
     pub async fn run(&mut self) -> Result<(), DriverError> {
         loop {
             if let Ok(byte) = nb_async(|| self.rx.read()).await {
+                defmt::trace!("Received byte, processing it now.");
+
                 if byte == b';' {
                     if let Ok(cmd) = Command::try_from(self.buffer_in.as_slice()) {
                         self.command_pipe

--- a/src/device/cli/downlink.rs
+++ b/src/device/cli/downlink.rs
@@ -51,9 +51,15 @@ where
                             .await
                             .map_err(|_| DriverError::ReceiverDropped)?;
                     }
+
+                    defmt::info!("End of command detected, clearing the input buffer now.");
                     self.buffer_in.clear();
                 } else {
                     if self.buffer_in.is_full() {
+                        defmt::warn!(
+                            "Input buffer reached total capacity. \
+                            Clearing the input buffer now, please start over again."
+                        );
                         self.buffer_in.clear();
                     }
                     // Safety: we've just made sure the buffer is not full

--- a/src/device/cli/receiver.rs
+++ b/src/device/cli/receiver.rs
@@ -36,6 +36,9 @@ impl CommandReceiver {
                 .recv()
                 .await
                 .map_err(|_| DriverError::DownlinkSenderDropped)?;
+
+            defmt::trace!("Received command, processing it now.");
+
             self.execute(cmd).await?;
         }
     }

--- a/src/device/cli/uplink.rs
+++ b/src/device/cli/uplink.rs
@@ -41,6 +41,9 @@ where
                 .recv()
                 .await
                 .map_err(|_| DriverError::SenderDropped)?;
+
+            defmt::trace!("Received string, processing it now.");
+
             write!(self.tx, "{msg}").map_err(|_| DriverError::FormatError)?;
             nb_async(|| self.tx.flush())
                 .await

--- a/src/game/driver.rs
+++ b/src/game/driver.rs
@@ -40,7 +40,7 @@ where
             State::TileNeeded(game, mut p) => match game.place_tile(p.generate_tile()) {
                 Either::Left(game) => State::TileFloating(game, p),
                 Either::Right(mut game) => {
-                    defmt::debug!("Game has ended, restarting.");
+                    defmt::info!("Game over, please try again!");
                     let o = game
                         .clear_observer()
                         .expect("game should have an observer set");

--- a/src/game/driver.rs
+++ b/src/game/driver.rs
@@ -195,8 +195,11 @@ where
                 ReceiveError::Empty => unreachable!(),
                 ReceiveError::NoSender => DriverError::SenderDropped,
             })?;
+
+            defmt::trace!("Received message, processing it now.");
+
             if !self.mailbox.is_empty() {
-                defmt::warn!("Processing game message, but more messages are pending.");
+                defmt::warn!("Additional messages are pending.");
             }
 
             match msg {

--- a/src/game/driver.rs
+++ b/src/game/driver.rs
@@ -40,7 +40,7 @@ where
             State::TileNeeded(game, mut p) => match game.place_tile(p.generate_tile()) {
                 Either::Left(game) => State::TileFloating(game, p),
                 Either::Right(mut game) => {
-                    defmt::info!("restarting game");
+                    defmt::debug!("Game has ended, restarting.");
                     let o = game
                         .clear_observer()
                         .expect("game should have an observer set");
@@ -64,17 +64,17 @@ where
     fn rotate(self) -> Self {
         if let State::TileFloating(mut game, p) = self {
             if game.rotate_tile().is_err() {
-                defmt::trace!("Ignoring invalid rotation");
+                defmt::debug!("Ignoring invalid rotation.");
             }
             State::TileFloating(game, p)
         } else {
-            defmt::trace!("Ignoring rotation due to invalid state");
+            defmt::debug!("Ignoring rotation due to inapplicable state.");
             self
         }
     }
 
     fn move_to(self, column: u8) -> Self {
-        defmt::trace!("column: {}", column);
+        defmt::debug!("column: {}", column);
 
         if let State::TileFloating(mut game, p) = self {
             let difference =
@@ -83,20 +83,20 @@ where
             for _ in 1..=difference.abs() {
                 if difference < 0 {
                     if game.move_tile_left().is_err() {
-                        defmt::trace!("Ignoring invalid move to the left");
+                        defmt::debug!("Ignoring invalid move to the left");
                         break;
                     }
                 } else {
                     #[allow(clippy::collapsible_else_if)] // keeping this for matching source layout
                     if game.move_tile_right().is_err() {
-                        defmt::trace!("Ignoring invalid move to the right");
+                        defmt::debug!("Ignoring invalid move to the right");
                         break;
                     }
                 }
             }
             Self::TileFloating(game, p)
         } else {
-            defmt::trace!("Ignoring horizontal movement due to invalid state");
+            defmt::debug!("Ignoring horizontal movement due to inapplicable state");
             self
         }
     }
@@ -192,13 +192,12 @@ where
     pub async fn run(&mut self) -> Result<(), DriverError> {
         loop {
             let msg = self.mailbox.recv().await.map_err(|e| match e {
-                ReceiveError::Empty => unreachable!(""),
+                ReceiveError::Empty => unreachable!(),
                 ReceiveError::NoSender => DriverError::SenderDropped,
             })?;
-            defmt::debug!(
-                "consuming message, more messages pending: {}",
-                !self.mailbox.is_empty()
-            );
+            if !self.mailbox.is_empty() {
+                defmt::warn!("Processing game message, but more messages are pending.");
+            }
 
             match msg {
                 Message::TimerTick => {


### PR DESCRIPTION
This PR streamlines issued calls to `demft`-based logging macros.

Closes #55 