### PR TITLE
feat: tweak used frequencies

### DIFF
--- a/src/bin/microtile.rs
+++ b/src/bin/microtile.rs
@@ -58,7 +58,7 @@ mod app {
     use microtile_engine::{gameplay::game::Observer, geometry::grid::Grid};
     use rtic_sync::channel::{Channel, TrySendError};
 
-    const HIGH_LEVEL_DISPLAY_FREQ: u32 = 5;
+    const HIGH_LEVEL_DISPLAY_FREQ: u32 = 6;
     const HIGH_LEVEL_DISPLAY_CYCLES: u32 =
         Timer::<HighLevelDisplayDriver, Periodic>::TICKS_PER_SECOND / HIGH_LEVEL_DISPLAY_FREQ;
 

--- a/src/bin/microtile.rs
+++ b/src/bin/microtile.rs
@@ -15,7 +15,7 @@ use microtile_app as _; // global logger + panicking-behavior + memory layout
 
 #[rtic::app(
     device = microbit_pac,
-    dispatchers = [SWI0_EGU0]
+    dispatchers = [SWI0_EGU0, SWI1_EGU1]
 )]
 mod app {
     use core::mem::MaybeUninit;
@@ -320,7 +320,7 @@ mod app {
         };
     }
 
-    #[task(priority = 1, shared = [ merged_frame, passive_frame ])]
+    #[task(priority = 2, shared = [ merged_frame, passive_frame ])]
     async fn update_frames(cx: update_frames::Context, active: Grid, passive: Grid) {
         defmt::trace!("microtile_app::update_frames()");
         (cx.shared.merged_frame, cx.shared.passive_frame).lock(|merged_frame, passive_frame| {

--- a/src/game/driver.rs
+++ b/src/game/driver.rs
@@ -199,7 +199,7 @@ where
             defmt::trace!("Received message, processing it now.");
 
             if !self.mailbox.is_empty() {
-                defmt::warn!("Additional messages are pending.");
+                defmt::debug!("Additional messages are pending.");
             }
 
             match msg {


### PR DESCRIPTION
Summary of what is implemented in this PR:

- demote warning in `GameDriver` when having multiple
  messages pending to debug print, as the condition of
  having multiple messages pending is not inherently
  problematic
- raise frame update task priority from 1 to 2 to allow for
  preemption (frame update preempting the surrounding
  `GameDriver` logic) and avoid frame updates getting
  dropped
- raise soft-drop frequency from 2Hz to 3Hz to make the
  change in speed more obvious to the user
- raise high-level display toggle frequency from 5Hz to 6Hz
  to have at least one blink per soft-drop interval

Closes #59 