### PR TITLE
feat: configure debug task in `vscode`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "preLaunchTask": "${defaultBuildTask}",
+            "type": "probe-rs-debug",
+            "request": "launch",
+            "name": "Debug microtile.rs",
+            "runtimeExecutable": "probe-rs",
+            "chip": "nRF52833_xxAA",
+            "coreConfigs": [
+                {
+                    "programBinary": "${workspaceFolder}/target/thumbv7em-none-eabihf/debug/microtile"
+                }
+            ],
+            "env": {
+                // If you set this variable, check the VSCode console log window for the location of the log file.
+                "RUST_LOG": "info",
+                "DEFMT_LOG": "info"
+            },
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"args": [
+				"--profile",
+				"dev",
+				"--bin",
+				"microtile"
+			],
+			"env": {
+				"DEFMT_LOG": "info",
+				"RUST_LOG": "info"
+			},
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "rust: cargo build"
+		}
+	]
+}


### PR DESCRIPTION
With this PR, a ready to use debug task for `vscode` is set up.

Closes #65 